### PR TITLE
Multi-mon support without extra configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,27 +77,6 @@ jobs:
           /p:AssemblyInformationalVersion=$env:FULLVERSION `
           --self-contained
 
-    - name: Azure Login
-      uses: azure/login@v2
-      with:
-        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-
-    - name: Sign executables with Trusted Signing
-      uses: azure/trusted-signing-action@v1
-      with:
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-        endpoint: https://wus2.codesigning.azure.net/
-        signing-account-name: hanselman
-        certificate-profile-name: WindowsEdgeLight
-        files-folder: ${{ github.workspace }}\src\MaximizeToVirtualDesktop\bin\Release\net10.0-windows
-        files-folder-filter: exe
-        files-folder-recurse: true
-        file-digest: SHA256
-        timestamp-rfc3161: http://timestamp.acs.microsoft.com
-        timestamp-digest: SHA256
-          
     - name: Prepare artifacts
       shell: pwsh
       run: |

--- a/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
+++ b/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
@@ -107,6 +107,35 @@ internal static partial class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
+    // --- Multi-Monitor Window Enumeration ---
+
+    internal delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    internal static extern int GetWindowTextLength(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    internal static extern int GetClassName(IntPtr hWnd, char[] lpClassName, int nMaxCount);
+
     [DllImport("advapi32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
@@ -175,6 +204,13 @@ internal static partial class NativeMethods
 
     internal const int HTMAXBUTTON = 9;
 
+    internal const int GWL_EXSTYLE = -20;
+    internal const int WS_EX_TOOLWINDOW = 0x00000080;
+    internal const int WS_EX_APPWINDOW = 0x00040000;
+    internal const uint SWP_NOSIZE = 0x0001;
+    internal const uint SWP_NOZORDER = 0x0004;
+    internal const uint SWP_NOACTIVATE = 0x0010;
+
     internal const int WH_MOUSE_LL = 14;
     internal const int HC_ACTION = 0;
 
@@ -241,6 +277,7 @@ internal static partial class NativeMethods
     }
 
     internal const uint SW_SHOWNORMAL = 1;
+    internal const uint SW_SHOWMINIMIZED = 2;
     internal const uint SW_SHOWMAXIMIZED = 3;
 
     // --- WinRT HString ---


### PR DESCRIPTION
In a multi-monitor setup, without extra configuration, when SHIFT + MAXIMIZING 

1. the window will be placed in the center monitor in the new Virtual Desktop
2. the windows from the surrounding monitors will come along in the new Virtual Desktop

In other word, in a multi-mon setup you can SHIFT + MAX any window and it becomes the main focus whilst everything else stays where it is. Then just undo the maximizing and it all goes back to how it was.