### PR TITLE
Added Hotkey Support for Windows Snap Assist & Powertoys Fancy Zones keyboard shortcuts

### DIFF
--- a/src/MaximizeToVirtualDesktop/FullScreenManager.cs
+++ b/src/MaximizeToVirtualDesktop/FullScreenManager.cs
@@ -271,11 +271,7 @@ internal sealed class FullScreenManager
 
         Trace.WriteLine($"FullScreenManager: Restoring {relatedWindows.Count} window(s) from temp desktop {entry.TempDesktopId}");
 
-        // Untrack all related windows first to prevent reentrant calls
-        foreach (var relatedEntry in relatedWindows)
-        {
-            _tracker.Untrack(relatedEntry.Hwnd);
-        }
+        // Untrack will be performed after successful restore
 
         var origDesktop = _vds.FindDesktop(entry.OriginalDesktopId);
         try
@@ -290,6 +286,8 @@ internal sealed class FullScreenManager
                 {
                     var placement = relatedEntry.OriginalPlacement;
                     NativeMethods.SetWindowPlacement(relatedEntry.Hwnd, ref placement);
+                    // Ensure the window is shown in its normal (not maximized) state
+                    NativeMethods.ShowWindow(relatedEntry.Hwnd, (int)NativeMethods.SW_SHOWNORMAL);
                 }
 
                 // Move window back to original desktop
@@ -319,6 +317,12 @@ internal sealed class FullScreenManager
         {
             _vds.RemoveDesktop(entry.TempDesktop);
             Marshal.ReleaseComObject(entry.TempDesktop);
+        }
+
+        // Untrack windows after successful restore
+        foreach (var relatedEntry in relatedWindows)
+        {
+            _tracker.Untrack(relatedEntry.Hwnd);
         }
 
         // Set focus on the primary restored window

--- a/src/MaximizeToVirtualDesktop/SettingsDialog.cs
+++ b/src/MaximizeToVirtualDesktop/SettingsDialog.cs
@@ -17,6 +17,7 @@ internal sealed class SettingsDialog : Form
     private readonly ComboBox _cmbPinKey;
 
     private readonly CheckBox _chkInvertShiftClick;
+    private readonly CheckBox _chkAlwaysMaximize;
 
     // (display name, VK code) pairs for the key combo boxes
     private static readonly (string Name, uint Vk)[] SupportedKeys =
@@ -62,15 +63,24 @@ internal sealed class SettingsDialog : Form
         y += grpPin.Height + 12;
 
         // Behavior group
-        var grpBehavior = new GroupBox { Text = "Behavior", Location = new Point(margin, y), Size = new Size(grpW, 80) };
+        var grpBehavior = new GroupBox { Text = "Behavior", Location = new Point(margin, y), Size = new Size(grpW, 100) };
         Controls.Add(grpBehavior);
+        // New checkbox for AlwaysMaximizeToVirtualDesktopsOnClick
+        _chkAlwaysMaximize = new CheckBox
+        {
+            Text = "Always maximize to virtual desktop on click",
+            AutoSize = true,
+            Checked = settings.AlwaysMaximizeToVirtualDesktopsOnClick,
+            Location = new Point(10, 20),
+        };
+        grpBehavior.Controls.Add(_chkAlwaysMaximize);
+        // Existing checkbox for InvertShiftClick
         _chkInvertShiftClick = new CheckBox
         {
-            Text = "Always maximize to virtual desktop on click\r\n" +
-                   "(Shift+Click performs a normal maximize instead)",
+            Text = "Shift+Click performs a normal maximize instead",
             AutoSize = true,
             Checked = settings.InvertShiftClick,
-            Location = new Point(10, 28),
+            Location = new Point(10, 48),
         };
         grpBehavior.Controls.Add(_chkInvertShiftClick);
         y += grpBehavior.Height + 16;
@@ -173,6 +183,7 @@ internal sealed class SettingsDialog : Form
         _chkPinWin.Checked   = false;
         _cmbPinKey.SelectedIndex = Array.FindIndex(SupportedKeys, k => k.Vk == NativeMethods.VK_P);
 
+        _chkAlwaysMaximize.Checked = true;
         _chkInvertShiftClick.Checked = false;
     }
 
@@ -207,6 +218,7 @@ internal sealed class SettingsDialog : Form
         _settings.HotkeyKey          = _cmbHotkeyKey.SelectedIndex >= 0 ? SupportedKeys[_cmbHotkeyKey.SelectedIndex].Vk : NativeMethods.VK_X;
         _settings.PinHotkeyModifiers = BuildModifiers(_chkPinCtrl, _chkPinAlt, _chkPinShift, _chkPinWin);
         _settings.PinHotkeyKey       = _cmbPinKey.SelectedIndex >= 0 ? SupportedKeys[_cmbPinKey.SelectedIndex].Vk : NativeMethods.VK_P;
+        _settings.AlwaysMaximizeToVirtualDesktopsOnClick = _chkAlwaysMaximize.Checked;
         _settings.InvertShiftClick   = _chkInvertShiftClick.Checked;
     }
 

--- a/src/MaximizeToVirtualDesktop/SettingsDialog.cs
+++ b/src/MaximizeToVirtualDesktop/SettingsDialog.cs
@@ -17,7 +17,6 @@ internal sealed class SettingsDialog : Form
     private readonly ComboBox _cmbPinKey;
 
     private readonly CheckBox _chkInvertShiftClick;
-    private readonly CheckBox _chkAlwaysMaximize;
 
     // (display name, VK code) pairs for the key combo boxes
     private static readonly (string Name, uint Vk)[] SupportedKeys =
@@ -65,15 +64,6 @@ internal sealed class SettingsDialog : Form
         // Behavior group
         var grpBehavior = new GroupBox { Text = "Behavior", Location = new Point(margin, y), Size = new Size(grpW, 100) };
         Controls.Add(grpBehavior);
-        // New checkbox for AlwaysMaximizeToVirtualDesktopsOnClick
-        _chkAlwaysMaximize = new CheckBox
-        {
-            Text = "Always maximize to virtual desktop on click",
-            AutoSize = true,
-            Checked = settings.AlwaysMaximizeToVirtualDesktopsOnClick,
-            Location = new Point(10, 20),
-        };
-        grpBehavior.Controls.Add(_chkAlwaysMaximize);
         // Existing checkbox for InvertShiftClick
         _chkInvertShiftClick = new CheckBox
         {
@@ -183,7 +173,6 @@ internal sealed class SettingsDialog : Form
         _chkPinWin.Checked   = false;
         _cmbPinKey.SelectedIndex = Array.FindIndex(SupportedKeys, k => k.Vk == NativeMethods.VK_P);
 
-        _chkAlwaysMaximize.Checked = true;
         _chkInvertShiftClick.Checked = false;
     }
 
@@ -218,7 +207,6 @@ internal sealed class SettingsDialog : Form
         _settings.HotkeyKey          = _cmbHotkeyKey.SelectedIndex >= 0 ? SupportedKeys[_cmbHotkeyKey.SelectedIndex].Vk : NativeMethods.VK_X;
         _settings.PinHotkeyModifiers = BuildModifiers(_chkPinCtrl, _chkPinAlt, _chkPinShift, _chkPinWin);
         _settings.PinHotkeyKey       = _cmbPinKey.SelectedIndex >= 0 ? SupportedKeys[_cmbPinKey.SelectedIndex].Vk : NativeMethods.VK_P;
-        _settings.AlwaysMaximizeToVirtualDesktopsOnClick = _chkAlwaysMaximize.Checked;
         _settings.InvertShiftClick   = _chkInvertShiftClick.Checked;
     }
 

--- a/src/MaximizeToVirtualDesktop/TrayApplication.cs
+++ b/src/MaximizeToVirtualDesktop/TrayApplication.cs
@@ -230,7 +230,14 @@ internal sealed class TrayApplication : Form
         }
 
         Trace.WriteLine($"TrayApplication: Hotkey pressed, toggling window {hwnd}");
-        _manager.Toggle(hwnd);
+        if (_settings.AlwaysMaximizeToVirtualDesktopsOnClick && !_settings.InvertShiftClick)
+        {
+            _manager.Toggle(hwnd);
+        }
+        else
+        {
+            Trace.WriteLine("TrayApplication: Maximize shortcut disabled by settings.");
+        }
     }
 
     private void OnPinHotkeyPressed()

--- a/src/MaximizeToVirtualDesktop/TrayApplication.cs
+++ b/src/MaximizeToVirtualDesktop/TrayApplication.cs
@@ -48,7 +48,7 @@ internal sealed class TrayApplication : Form
         _vds = new VirtualDesktopService();
         _tracker = new FullScreenTracker();
         _manager = new FullScreenManager(_vds, _tracker);
-        _monitor = new WindowMonitor(_manager, _tracker, this);
+        _monitor = new WindowMonitor(_manager, _tracker, this, _settings);
         _mouseHook = new MaximizeButtonHook(_manager, this, _settings);
 
         // System tray icon
@@ -230,14 +230,7 @@ internal sealed class TrayApplication : Form
         }
 
         Trace.WriteLine($"TrayApplication: Hotkey pressed, toggling window {hwnd}");
-        if (_settings.AlwaysMaximizeToVirtualDesktopsOnClick && !_settings.InvertShiftClick)
-        {
-            _manager.Toggle(hwnd);
-        }
-        else
-        {
-            Trace.WriteLine("TrayApplication: Maximize shortcut disabled by settings.");
-        }
+        _manager.Toggle(hwnd);
     }
 
     private void OnPinHotkeyPressed()

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -80,27 +80,18 @@ internal sealed class WindowMonitor : IDisposable
     {
         // Only care about top-level window changes (OBJID_WINDOW)
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
-        // Debug: Log entry into OnLocationChange for tracing shortcut handling
-        Trace.WriteLine($"WindowMonitor: OnLocationChange triggered for hwnd={hwnd}, eventType={eventType}");
+
         // If the window is already tracked, check if it is being restored (i.e., no longer maximized)
         if (_tracker.IsTracked(hwnd))
         {
-            // Tracked window event: log current placement for debugging
             var placement = NativeMethods.WINDOWPLACEMENT.Default;
             if (NativeMethods.GetWindowPlacement(hwnd, ref placement))
             {
-                Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} current showCmd={placement.showCmd}, checking for restore.");
-                // Log detailed state
-                Trace.WriteLine($"WindowMonitor: Placement details: flags={placement.flags}, ptMinPosition=({placement.ptMinPosition.X},{placement.ptMinPosition.Y}), ptMaxPosition=({placement.ptMaxPosition.X},{placement.ptMaxPosition.Y}), rcNormalPosition=({placement.rcNormalPosition.Left},{placement.rcNormalPosition.Top},{placement.rcNormalPosition.Right},{placement.rcNormalPosition.Bottom})");
                 if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
                 {
-                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} restored via location change, invoking restore.");
+                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} restored via location change.");
                     MarshalToUiThread(() => _manager.Restore(hwnd));
                     return;
-                }
-                else
-                {
-                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} still maximized; awaiting MoveSizeEnd.");
                 }
             }
             // Still maximized; let MoveSizeEnd handle pending maximize.
@@ -110,11 +101,11 @@ internal sealed class WindowMonitor : IDisposable
         // Not tracked yet: check for a new maximize event (including via shortcut)
         var newPlacement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
-        // Log the detected placement for debugging purposes
-        Trace.WriteLine($"WindowMonitor: Detected placement.showCmd={newPlacement.showCmd} for hwnd={hwnd}");
+        if (newPlacement.showCmd != NativeMethods.SW_MAXIMIZE) return;
+
         bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
         bool triggerVirtualDesktop = _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
-        if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE && triggerVirtualDesktop)
+        if (triggerVirtualDesktop)
         {
             // Defer maximization until after the resize operation completes
             MarshalToUiThread(() =>
@@ -175,10 +166,10 @@ internal sealed class WindowMonitor : IDisposable
         if (!_tracker.IsTracked(hwnd)) return;
         var placement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref placement)) return;
-        Trace.WriteLine($"WindowMonitor: MoveSizeEnd: placement.showCmd={placement.showCmd}, flags={placement.flags}, ptMinPosition=({placement.ptMinPosition.X},{placement.ptMinPosition.Y}), ptMaxPosition=({placement.ptMaxPosition.X},{placement.ptMaxPosition.Y}), rcNormalPosition=({placement.rcNormalPosition.Left},{placement.rcNormalPosition.Top},{placement.rcNormalPosition.Right},{placement.rcNormalPosition.Bottom})");
+        Trace.WriteLine($"WindowMonitor: MoveSizeEnd: tracked window {hwnd} showCmd={placement.showCmd}.");
         if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
         {
-            Trace.WriteLine($"WindowMonitor: MoveSizeEnd detected un-maximized tracked window {hwnd}, restoring after delay.");
+            Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} un-maximized via move/size, restoring.");
             await Task.Delay(100);
             MarshalToUiThread(() => _manager.Restore(hwnd));
         }

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -80,22 +80,63 @@ internal sealed class WindowMonitor : IDisposable
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
         // Debug: Log entry into OnLocationChange for tracing shortcut handling
         Trace.WriteLine($"WindowMonitor: OnLocationChange triggered for hwnd={hwnd}, eventType={eventType}");
-        // If the window is already tracked, handle un-maximize restoration
+        // If the window is already tracked, check if it is being restored (i.e., no longer maximized)
         if (_tracker.IsTracked(hwnd))
         {
-            // Let other listeners handle restoration; will be processed in MoveSizeEnd handler.
+            // Tracked window event: log current placement for debugging
+            var placement = NativeMethods.WINDOWPLACEMENT.Default;
+            if (NativeMethods.GetWindowPlacement(hwnd, ref placement))
+            {
+                Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} current showCmd={placement.showCmd}, checking for restore.");
+                // Log detailed state
+                Trace.WriteLine($"WindowMonitor: Placement details: flags={placement.flags}, ptMinPosition=({placement.ptMinPosition.X},{placement.ptMinPosition.Y}), ptMaxPosition=({placement.ptMaxPosition.X},{placement.ptMaxPosition.Y}), rcNormalPosition=({placement.rcNormalPosition.Left},{placement.rcNormalPosition.Top},{placement.rcNormalPosition.Right},{placement.rcNormalPosition.Bottom})");
+                if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
+                {
+                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} restored via location change, invoking restore.");
+                    MarshalToUiThread(() => _manager.Restore(hwnd));
+                    return;
+                }
+                else
+                {
+                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} still maximized; awaiting MoveSizeEnd.");
+                }
+            }
+            // Still maximized; let MoveSizeEnd handle pending maximize.
             return;
         }
 
         // Not tracked yet: check for a new maximize event (including via shortcut)
         var newPlacement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
+        // Log the detected placement for debugging purposes
+        Trace.WriteLine($"WindowMonitor: Detected placement.showCmd={newPlacement.showCmd} for hwnd={hwnd}");
         if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE)
         {
             // Defer maximization until after the resize operation completes
             if (_pendingMaximize.Add(hwnd))
             {
                 Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
+                // Schedule a fallback in case MoveSizeEnd does not fire (e.g., keyboard shortcut)
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(200);
+                    if (_pendingMaximize.Contains(hwnd))
+                    {
+                        _pendingMaximize.Remove(hwnd);
+                        var placement = NativeMethods.WINDOWPLACEMENT.Default;
+                        bool isMaximized = NativeMethods.GetWindowPlacement(hwnd, ref placement) && placement.showCmd == NativeMethods.SW_MAXIMIZE;
+                        if (isMaximized)
+                        {
+                            Trace.WriteLine($"WindowMonitor: Fallback processing for pending maximize window {hwnd}.");
+                            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
+                        }
+                        else
+                        {
+                            Trace.WriteLine($"WindowMonitor: Fallback detected restore for pending window {hwnd}.");
+                            MarshalToUiThread(() => _manager.Restore(hwnd));
+                        }
+                    }
+                });
             }
         }
     }
@@ -118,6 +159,7 @@ internal sealed class WindowMonitor : IDisposable
         if (!_tracker.IsTracked(hwnd)) return;
         var placement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref placement)) return;
+        Trace.WriteLine($"WindowMonitor: MoveSizeEnd: placement.showCmd={placement.showCmd}, flags={placement.flags}, ptMinPosition=({placement.ptMinPosition.X},{placement.ptMinPosition.Y}), ptMaxPosition=({placement.ptMaxPosition.X},{placement.ptMaxPosition.Y}), rcNormalPosition=({placement.rcNormalPosition.Left},{placement.rcNormalPosition.Top},{placement.rcNormalPosition.Right},{placement.rcNormalPosition.Bottom})");
         if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
         {
             Trace.WriteLine($"WindowMonitor: MoveSizeEnd detected un-maximized tracked window {hwnd}, restoring after delay.");

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -25,6 +25,7 @@ internal sealed class WindowMonitor : IDisposable
     private readonly NativeMethods.WinEventProc _moveSizeEndProc;
     private IntPtr _moveSizeEndHook;
     // Track windows that have been maximized but need to wait for resize end
+    // Access to this set must happen only on the UI thread.
     private readonly HashSet<IntPtr> _pendingMaximize = new();
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl, AppSettings settings)
@@ -116,31 +117,38 @@ internal sealed class WindowMonitor : IDisposable
         if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE && triggerVirtualDesktop)
         {
             // Defer maximization until after the resize operation completes
-            if (_pendingMaximize.Add(hwnd))
+            MarshalToUiThread(() =>
             {
-                Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
-                // Schedule a fallback in case MoveSizeEnd does not fire (e.g., keyboard shortcut)
-                _ = Task.Run(async () =>
+                if (_pendingMaximize.Add(hwnd))
                 {
-                    await Task.Delay(200);
-                    if (_pendingMaximize.Contains(hwnd))
+                    Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
+                    // Schedule a fallback in case MoveSizeEnd does not fire (e.g., keyboard shortcut)
+                    _ = Task.Run(async () =>
                     {
-                        _pendingMaximize.Remove(hwnd);
-                        var placement = NativeMethods.WINDOWPLACEMENT.Default;
-                        bool isMaximized = NativeMethods.GetWindowPlacement(hwnd, ref placement) && placement.showCmd == NativeMethods.SW_MAXIMIZE;
-                        if (isMaximized)
+                        await Task.Delay(200);
+                        // Marshal the check/remove back onto the UI thread
+                        MarshalToUiThread(() =>
                         {
-                            Trace.WriteLine($"WindowMonitor: Fallback processing for pending maximize window {hwnd}.");
-                            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
-                        }
-                        else
-                        {
-                            Trace.WriteLine($"WindowMonitor: Fallback detected restore for pending window {hwnd}.");
-                            MarshalToUiThread(() => _manager.Restore(hwnd));
-                        }
-                    }
-                });
-            }
+                            if (_pendingMaximize.Contains(hwnd))
+                            {
+                                _pendingMaximize.Remove(hwnd);
+                                var placement = NativeMethods.WINDOWPLACEMENT.Default;
+                                bool isMaximized = NativeMethods.GetWindowPlacement(hwnd, ref placement) && placement.showCmd == NativeMethods.SW_MAXIMIZE;
+                                if (isMaximized)
+                                {
+                                    Trace.WriteLine($"WindowMonitor: Fallback processing for pending maximize window {hwnd}.");
+                                    _manager.MaximizeToDesktop(hwnd);
+                                }
+                                else
+                                {
+                                    Trace.WriteLine($"WindowMonitor: Fallback detected restore for pending window {hwnd}.");
+                                    _manager.Restore(hwnd);
+                                }
+                            }
+                        });
+                    });
+                }
+            });
         }
     }
 
@@ -151,7 +159,12 @@ internal sealed class WindowMonitor : IDisposable
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
 
         // If this window was pending maximize, handle it now
-        if (_pendingMaximize.Remove(hwnd))
+        bool wasPending = false;
+        if (!_syncControl.IsDisposed && _syncControl.IsHandleCreated)
+        {
+            wasPending = (bool)_syncControl.Invoke(new Func<bool>(() => _pendingMaximize.Remove(hwnd)));
+        }
+        if (wasPending)
         {
             Trace.WriteLine($"WindowMonitor: MoveSizeEnd triggered for pending maximize window {hwnd}.");
             MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using MaximizeToVirtualDesktop.Interop;
 
 namespace MaximizeToVirtualDesktop;
@@ -20,6 +22,10 @@ internal sealed class WindowMonitor : IDisposable
     // Must be stored as fields to prevent GC collection of the delegate
     private readonly NativeMethods.WinEventProc _locationChangeProc;
     private readonly NativeMethods.WinEventProc _destroyProc;
+    private readonly NativeMethods.WinEventProc _moveSizeEndProc;
+    private IntPtr _moveSizeEndHook;
+    // Track windows that have been maximized but need to wait for resize end
+    private readonly HashSet<IntPtr> _pendingMaximize = new();
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl)
     {
@@ -29,6 +35,7 @@ internal sealed class WindowMonitor : IDisposable
 
         _locationChangeProc = OnLocationChange;
         _destroyProc = OnDestroy;
+        _moveSizeEndProc = OnMoveSizeEnd;
     }
 
     public void Start()
@@ -40,6 +47,13 @@ internal sealed class WindowMonitor : IDisposable
             NativeMethods.EVENT_OBJECT_LOCATIONCHANGE,
             NativeMethods.EVENT_OBJECT_LOCATIONCHANGE,
             IntPtr.Zero, _locationChangeProc,
+            0, 0, NativeMethods.WINEVENT_OUTOFCONTEXT);
+
+        // EVENT_SYSTEM_MOVESIZEEND fires after a window finishes moving or resizing (including maximize via shortcuts)
+        _moveSizeEndHook = NativeMethods.SetWinEventHook(
+            NativeMethods.EVENT_SYSTEM_MOVESIZEEND,
+            NativeMethods.EVENT_SYSTEM_MOVESIZEEND,
+            IntPtr.Zero, _moveSizeEndProc,
             0, 0, NativeMethods.WINEVENT_OUTOFCONTEXT);
 
         // EVENT_OBJECT_DESTROY fires when a window is closed
@@ -64,16 +78,50 @@ internal sealed class WindowMonitor : IDisposable
     {
         // Only care about top-level window changes (OBJID_WINDOW)
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
-        if (!_tracker.IsTracked(hwnd)) return;
+        // Debug: Log entry into OnLocationChange for tracing shortcut handling
+        Trace.WriteLine($"WindowMonitor: OnLocationChange triggered for hwnd={hwnd}, eventType={eventType}");
+        // If the window is already tracked, handle un-maximize restoration
+        if (_tracker.IsTracked(hwnd))
+        {
+            // Let other listeners handle restoration; will be processed in MoveSizeEnd handler.
+            return;
+        }
 
-        // Check if window is still maximized
+        // Not tracked yet: check for a new maximize event (including via shortcut)
+        var newPlacement = NativeMethods.WINDOWPLACEMENT.Default;
+        if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
+        if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE)
+        {
+            // Defer maximization until after the resize operation completes
+            if (_pendingMaximize.Add(hwnd))
+            {
+                Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
+            }
+        }
+    }
+
+    private async void OnMoveSizeEnd(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
+        int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
+    {
+        // Only care about top-level window changes (OBJID_WINDOW)
+        if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
+
+        // If this window was pending maximize, handle it now
+        if (_pendingMaximize.Remove(hwnd))
+        {
+            Trace.WriteLine($"WindowMonitor: MoveSizeEnd triggered for pending maximize window {hwnd}.");
+            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
+            return;
+        }
+
+        // Handle only tracked windows that are being restored (not maximized)
+        if (!_tracker.IsTracked(hwnd)) return;
         var placement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref placement)) return;
-
-        if (placement.showCmd != NativeMethods.SW_SHOWMAXIMIZED)
+        if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
         {
-            // Window was un-maximized — restore it
-            Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} un-maximized, restoring.");
+            Trace.WriteLine($"WindowMonitor: MoveSizeEnd detected un-maximized tracked window {hwnd}, restoring after delay.");
+            await Task.Delay(100);
             MarshalToUiThread(() => _manager.Restore(hwnd));
         }
     }
@@ -116,6 +164,11 @@ internal sealed class WindowMonitor : IDisposable
         {
             NativeMethods.UnhookWinEvent(_destroyHook);
             _destroyHook = IntPtr.Zero;
+        }
+        if (_moveSizeEndHook != IntPtr.Zero)
+        {
+            NativeMethods.UnhookWinEvent(_moveSizeEndHook);
+            _moveSizeEndHook = IntPtr.Zero;
         }
 
         Trace.WriteLine("WindowMonitor: Disposed.");

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -24,8 +24,7 @@ internal sealed class WindowMonitor : IDisposable
     private readonly NativeMethods.WinEventProc _destroyProc;
     private readonly NativeMethods.WinEventProc _moveSizeEndProc;
     private IntPtr _moveSizeEndHook;
-    // Track windows that have been maximized but need to wait for resize end
-    private readonly HashSet<IntPtr> _pendingMaximize = new();
+    // (Pending maximize handling removed; using direct delayed task)
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl)
     {
@@ -92,10 +91,16 @@ internal sealed class WindowMonitor : IDisposable
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
         if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE)
         {
-            // Defer maximization until after the resize operation completes
-            if (_pendingMaximize.Add(hwnd))
+            // Directly handle maximize via shortcut with a short delay to allow any resize to settle
+            if (!_tracker.IsTracked(hwnd))
             {
-                Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
+                Trace.WriteLine($"WindowMonitor: Detected maximize shortcut for window {hwnd}, scheduling move to virtual desktop.");
+                // Schedule async task to delay briefly then invoke MaximizeToDesktop
+                Task.Run(async () =>
+                {
+                    await Task.Delay(150); // allow system to finalize maximize state
+                    MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
+                });
             }
         }
     }
@@ -105,14 +110,6 @@ internal sealed class WindowMonitor : IDisposable
     {
         // Only care about top-level window changes (OBJID_WINDOW)
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
-
-        // If this window was pending maximize, handle it now
-        if (_pendingMaximize.Remove(hwnd))
-        {
-            Trace.WriteLine($"WindowMonitor: MoveSizeEnd triggered for pending maximize window {hwnd}.");
-            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
-            return;
-        }
 
         // Handle only tracked windows that are being restored (not maximized)
         if (!_tracker.IsTracked(hwnd)) return;

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -14,7 +14,7 @@ internal sealed class WindowMonitor : IDisposable
     private readonly FullScreenManager _manager;
     private readonly FullScreenTracker _tracker;
     private readonly Control _syncControl;
-
+    private readonly AppSettings _settings;
     private IntPtr _locationChangeHook;
     private IntPtr _destroyHook;
     private bool _disposed;
@@ -27,11 +27,12 @@ internal sealed class WindowMonitor : IDisposable
     // Track windows that have been maximized but need to wait for resize end
     private readonly HashSet<IntPtr> _pendingMaximize = new();
 
-    public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl)
+    public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl, AppSettings settings)
     {
         _manager = manager;
         _tracker = tracker;
         _syncControl = syncControl;
+        _settings = settings;
 
         _locationChangeProc = OnLocationChange;
         _destroyProc = OnDestroy;
@@ -110,7 +111,9 @@ internal sealed class WindowMonitor : IDisposable
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
         // Log the detected placement for debugging purposes
         Trace.WriteLine($"WindowMonitor: Detected placement.showCmd={newPlacement.showCmd} for hwnd={hwnd}");
-        if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE)
+        bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
+        bool triggerVirtualDesktop = _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
+        if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE && triggerVirtualDesktop)
         {
             // Defer maximization until after the resize operation completes
             if (_pendingMaximize.Add(hwnd))

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -24,7 +24,8 @@ internal sealed class WindowMonitor : IDisposable
     private readonly NativeMethods.WinEventProc _destroyProc;
     private readonly NativeMethods.WinEventProc _moveSizeEndProc;
     private IntPtr _moveSizeEndHook;
-    // (Pending maximize handling removed; using direct delayed task)
+    // Track windows that have been maximized but need to wait for resize end
+    private readonly HashSet<IntPtr> _pendingMaximize = new();
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl)
     {
@@ -91,16 +92,10 @@ internal sealed class WindowMonitor : IDisposable
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
         if (newPlacement.showCmd == NativeMethods.SW_MAXIMIZE)
         {
-            // Directly handle maximize via shortcut with a short delay to allow any resize to settle
-            if (!_tracker.IsTracked(hwnd))
+            // Defer maximization until after the resize operation completes
+            if (_pendingMaximize.Add(hwnd))
             {
-                Trace.WriteLine($"WindowMonitor: Detected maximize shortcut for window {hwnd}, scheduling move to virtual desktop.");
-                // Schedule async task to delay briefly then invoke MaximizeToDesktop
-                Task.Run(async () =>
-                {
-                    await Task.Delay(150); // allow system to finalize maximize state
-                    MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
-                });
+                Trace.WriteLine($"WindowMonitor: Queued maximize for window {hwnd} after resize end.");
             }
         }
     }
@@ -110,6 +105,14 @@ internal sealed class WindowMonitor : IDisposable
     {
         // Only care about top-level window changes (OBJID_WINDOW)
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
+
+        // If this window was pending maximize, handle it now
+        if (_pendingMaximize.Remove(hwnd))
+        {
+            Trace.WriteLine($"WindowMonitor: MoveSizeEnd triggered for pending maximize window {hwnd}.");
+            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
+            return;
+        }
 
         // Handle only tracked windows that are being restored (not maximized)
         if (!_tracker.IsTracked(hwnd)) return;


### PR DESCRIPTION
The application ignored Windows Snap keyboard shortcuts when determining whether to create a new virtual desktop and/or restor a window that is maximized on it's own virtual desktop.

Now if you use Fancy Zones your windows+arrow keys will also maximize to a new window! You will need the Settings checkbox to have the "Shift+Click performs a normal maximize instead" setting selected to make this work.