### PR TITLE
fix: minimize button&dragging title bar behavior, maximize animation flicker, and virtual desktop cleanup

### DIFF
--- a/src/MaximizeToVirtualDesktop/FullScreenManager.cs
+++ b/src/MaximizeToVirtualDesktop/FullScreenManager.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 using MaximizeToVirtualDesktop.Interop;
 
 namespace MaximizeToVirtualDesktop;
@@ -14,18 +13,13 @@ internal sealed class FullScreenManager
     private readonly VirtualDesktopService _vds;
     private readonly FullScreenTracker _tracker;
     private readonly AppSettings _settings;
-    private readonly Control _syncControl;
     private readonly HashSet<IntPtr> _inFlight = new();
-    // Track temp desktop COM refs that have already been released to prevent double-release.
-    // Multiple tracked windows may share the same TempDesktop COM pointer.
-    private readonly HashSet<Guid> _releasedDesktops = new();
 
-    public FullScreenManager(VirtualDesktopService vds, FullScreenTracker tracker, AppSettings settings, Control syncControl)
+    public FullScreenManager(VirtualDesktopService vds, FullScreenTracker tracker, AppSettings settings)
     {
         _vds = vds;
         _tracker = tracker;
         _settings = settings;
-        _syncControl = syncControl;
     }
 
     /// <summary>
@@ -117,39 +111,39 @@ internal sealed class FullScreenManager
         }
         catch { /* Non-critical */ }
 
-        // 4. Maximize & switch
+        // 4. Maximize, move, and switch
         bool elevated = NativeMethods.IsWindowElevated(hwnd);
 
         if (!elevated && NativeMethods.IsWindow(hwnd))
         {
             NativeMethods.ShowWindow(hwnd, NativeMethods.SW_MAXIMIZE);
-            var waitUntil = Environment.TickCount + 300;
-            while (Environment.TickCount < waitUntil)
-            {
-                Application.DoEvents();
-                Thread.Sleep(10);
-            }
+            Thread.Sleep(250);
         }
-
-        _vds.PinWindow(hwnd);
-
-        if (!_vds.SwitchToDesktop(tempDesktop))
+        else if (elevated)
         {
-            _vds.UnpinWindow(hwnd);
-            RollbackSwitch(tempDesktop, originalDesktopId.Value, hwnd, originalPlacement, elevated);
-            return;
+            Trace.WriteLine("FullScreenManager: Window is elevated, cannot maximize via UIPI.");
+            if (_settings.ShowSwitchPopup)
+            {
+                NotificationOverlay.ShowNotification("⚠ Elevated Window",
+                    "Press Win+↑ to maximize", hwnd);
+            }
         }
 
         if (!_vds.MoveWindowToDesktop(hwnd, tempDesktop))
         {
-            _vds.UnpinWindow(hwnd);
-            RollbackSwitch(tempDesktop, originalDesktopId.Value, hwnd, originalPlacement, elevated);
+            RollbackMaximize(tempDesktop, originalDesktopId.Value, hwnd,
+                originalPlacement, elevated, windowMoved: false);
             return;
         }
 
-        _vds.UnpinWindow(hwnd);
+        if (!_vds.SwitchToDesktop(tempDesktop))
+        {
+            RollbackMaximize(tempDesktop, originalDesktopId.Value, hwnd,
+                originalPlacement, elevated, windowMoved: true);
+            return;
+        }
 
-        ScheduleFocusRetry(hwnd, 4);
+        NativeMethods.SetForegroundWindow(hwnd);
 
         // 5. Track
         _tracker.Track(hwnd, originalDesktopId.Value, tempDesktopId.Value, tempDesktop, processName, originalPlacement);
@@ -162,73 +156,42 @@ internal sealed class FullScreenManager
     }
 
     /// <summary>
-    /// Retry SetForegroundWindow using AttachThreadInput to yield focus
-    /// without sending synthetic keystrokes that could trigger UI side effects (e.g. Word ribbon).
+    /// Roll back a failed maximize operation and remove the temporary desktop.
     /// </summary>
-    private void ScheduleFocusRetry(IntPtr hwnd, int attempts)
+    private void RollbackMaximize(IVirtualDesktop tempDesktop, Guid originalDesktopId,
+        IntPtr hwnd, NativeMethods.WINDOWPLACEMENT originalPlacement, bool elevated,
+        bool windowMoved)
     {
-        _ = Task.Run(async () =>
-        {
-            for (int i = 0; i < attempts; i++)
-            {
-                await Task.Delay(80);
-                if (!_syncControl.IsDisposed && _syncControl.IsHandleCreated)
-                {
-                    try
-                    {
-                        _syncControl.BeginInvoke(() =>
-                        {
-                            if (NativeMethods.IsWindow(hwnd))
-                            {
-                                uint targetThread = NativeMethods.GetWindowThreadProcessId(hwnd, out _);
-                                uint currentThread = NativeMethods.GetCurrentThreadId();
-                                NativeMethods.AttachThreadInput(targetThread, currentThread, true);
-                                try
-                                {
-                                    NativeMethods.SetForegroundWindow(hwnd);
-                                    NativeMethods.SetFocus(hwnd);
-                                }
-                                finally
-                                {
-                                    NativeMethods.AttachThreadInput(targetThread, currentThread, false);
-                                }
-                            }
-                        });
-                    }
-                    catch (ObjectDisposedException) { break; }
-                }
-            }
-        });
-    }
-
-    /// <summary>
-    /// Rollback a failed desktop switch: restore window placement, move windows back, remove temp desktop.
-    /// </summary>
-    private void RollbackSwitch(IVirtualDesktop tempDesktop, Guid originalDesktopId,
-        IntPtr hwnd, NativeMethods.WINDOWPLACEMENT originalPlacement, bool elevated)
-    {
-        Trace.WriteLine("FullScreenManager: Failed desktop switch, rolling back.");
-        if (!elevated && NativeMethods.IsWindow(hwnd))
-        {
-            var p = originalPlacement;
-            NativeMethods.SetWindowPlacement(hwnd, ref p);
-        }
+        Trace.WriteLine("FullScreenManager: Maximize operation failed, rolling back.");
         var origDesktop = _vds.FindDesktop(originalDesktopId);
         try
         {
-            if (origDesktop != null) _vds.MoveWindowToDesktop(hwnd, origDesktop);
+            if (windowMoved && origDesktop != null)
+                _vds.MoveWindowToDesktop(hwnd, origDesktop);
+
+            if (origDesktop != null && _vds.GetCurrentDesktopId() != originalDesktopId)
+                _vds.SwitchToDesktop(origDesktop);
         }
         finally { if (origDesktop != null) Marshal.ReleaseComObject(origDesktop); }
-        _vds.RemoveDesktop(tempDesktop);
+
+        if (!elevated && NativeMethods.IsWindow(hwnd))
+        {
+            var placement = originalPlacement;
+            NativeMethods.SetWindowPlacement(hwnd, ref placement);
+        }
+
+        if (!_vds.RemoveDesktop(tempDesktop))
+            Trace.WriteLine("FullScreenManager: Failed to remove temporary desktop during rollback.");
         Marshal.ReleaseComObject(tempDesktop);
     }
 
     /// <summary>
     /// Restore a tracked window: move it back to its original desktop, restore window state,
     /// switch back, and remove the temp desktop.
-    /// When <paramref name="keepMinimized"/> is true, the window stays minimized (only desktop cleanup is performed).
+    /// When <paramref name="keepMinimized"/> or <paramref name="keepHidden"/> is true,
+    /// preserve that visibility state while restoring the original placement.
     /// </summary>
-    public void Restore(IntPtr hwnd, bool keepMinimized = false)
+    public void Restore(IntPtr hwnd, bool keepMinimized = false, bool keepHidden = false)
     {
         var entry = _tracker.Get(hwnd);
         if (entry == null)
@@ -239,29 +202,23 @@ internal sealed class FullScreenManager
 
         Trace.WriteLine($"FullScreenManager: Restoring window {hwnd} from temp desktop {entry.TempDesktopId}");
 
-        // Untrack will be performed after successful restore
-
         var origDesktop = _vds.FindDesktop(entry.OriginalDesktopId);
+        bool restored = true;
         try
         {
-            _vds.PinWindow(hwnd);
-
-            if (origDesktop != null) _vds.SwitchToDesktop(origDesktop);
             if (origDesktop != null && NativeMethods.IsWindow(hwnd))
-                _vds.MoveWindowToDesktop(hwnd, origDesktop);
+                restored = _vds.MoveWindowToDesktop(hwnd, origDesktop);
 
-            _vds.UnpinWindow(hwnd);
-
-            if (!keepMinimized && NativeMethods.IsWindow(hwnd))
+            var currentDesktopId = _vds.GetCurrentDesktopId();
+            if (origDesktop != null
+                && (currentDesktopId == null || currentDesktopId == entry.TempDesktopId))
             {
-                var cur = NativeMethods.WINDOWPLACEMENT.Default;
-                if (NativeMethods.GetWindowPlacement(hwnd, ref cur)
-                    && cur.showCmd == NativeMethods.SW_MAXIMIZE)
-                {
-                    var placement = entry.OriginalPlacement;
-                    NativeMethods.SetWindowPlacement(hwnd, ref placement);
-                }
-                NativeMethods.ShowWindow(hwnd, (int)NativeMethods.SW_SHOWNORMAL);
+                restored = _vds.SwitchToDesktop(origDesktop) && restored;
+            }
+
+            if (restored && NativeMethods.IsWindow(hwnd))
+            {
+                RestoreWindowPlacement(hwnd, entry, keepMinimized, keepHidden);
             }
         }
         finally
@@ -269,27 +226,56 @@ internal sealed class FullScreenManager
             if (origDesktop != null) Marshal.ReleaseComObject(origDesktop);
         }
 
-        // Remove temp desktop and release its COM reference
-        if (_releasedDesktops.Add(entry.TempDesktopId))
+        if (!restored)
         {
-            _vds.RemoveDesktop(entry.TempDesktop);
-            Marshal.ReleaseComObject(entry.TempDesktop);
+            Trace.WriteLine($"FullScreenManager: Could not restore window {hwnd}; keeping it tracked for retry.");
+            return;
         }
-      
+
+        if (!_vds.RemoveDesktop(entry.TempDesktop))
+        {
+            Trace.WriteLine($"FullScreenManager: Could not remove desktop {entry.TempDesktopId}; keeping it tracked for recovery.");
+            return;
+        }
+
+        Marshal.ReleaseComObject(entry.TempDesktop);
         _tracker.Untrack(hwnd);
 
-        // Set focus on the restored window (skip if minimized)
-        if (!keepMinimized && NativeMethods.IsWindow(hwnd))
+        if (!keepMinimized && !keepHidden && NativeMethods.IsWindow(hwnd))
         {
             NativeMethods.SetForegroundWindow(hwnd);
-            ScheduleFocusRetry(hwnd, 2);
         }
 
-        if (_settings.ShowSwitchPopup)
+        if (_settings.ShowSwitchPopup && !keepHidden)
         {
             NotificationOverlay.ShowNotification("← Restored", entry.ProcessName ?? "", hwnd);
         }
         Trace.WriteLine($"FullScreenManager: Restored window to original desktop.");
+    }
+
+    private static void RestoreWindowPlacement(IntPtr hwnd, TrackingEntry entry,
+        bool keepMinimized, bool keepHidden)
+    {
+        if (keepMinimized || keepHidden)
+        {
+            var placement = entry.OriginalPlacement;
+            if (entry.OriginalPlacement.showCmd != NativeMethods.SW_MAXIMIZE)
+                placement.flags &= ~NativeMethods.WPF_RESTORETOMAXIMIZED;
+            placement.showCmd = keepHidden
+                ? NativeMethods.SW_HIDE
+                : NativeMethods.SW_SHOWMINNOACTIVE;
+            NativeMethods.SetWindowPlacement(hwnd, ref placement);
+            return;
+        }
+
+        var current = NativeMethods.WINDOWPLACEMENT.Default;
+        if (NativeMethods.GetWindowPlacement(hwnd, ref current)
+            && current.showCmd == NativeMethods.SW_MAXIMIZE)
+        {
+            var placement = entry.OriginalPlacement;
+            NativeMethods.SetWindowPlacement(hwnd, ref placement);
+        }
+        NativeMethods.ShowWindow(hwnd, (int)NativeMethods.SW_SHOWNORMAL);
     }
 
     /// <summary>
@@ -297,30 +283,37 @@ internal sealed class FullScreenManager
     /// </summary>
     public void HandleWindowDestroyed(IntPtr hwnd)
     {
-        var entry = _tracker.Untrack(hwnd);
+        var entry = _tracker.Get(hwnd);
         if (entry == null) return;
 
         Trace.WriteLine($"FullScreenManager: Tracked window {hwnd} destroyed.");
 
         Trace.WriteLine($"FullScreenManager: Cleaning up temp desktop {entry.TempDesktopId}");
 
-        // Switch back to original desktop first
         var origDesktop = _vds.FindDesktop(entry.OriginalDesktopId);
+        bool switched = true;
         try
         {
-            if (origDesktop != null) _vds.SwitchToDesktop(origDesktop);
+            var currentDesktopId = _vds.GetCurrentDesktopId();
+            if (origDesktop != null
+                && (currentDesktopId == null || currentDesktopId == entry.TempDesktopId))
+            {
+                switched = _vds.SwitchToDesktop(origDesktop);
+            }
         }
         finally
         {
             if (origDesktop != null) Marshal.ReleaseComObject(origDesktop);
         }
 
-        // Remove the temp desktop and release its COM reference
-        if (_releasedDesktops.Add(entry.TempDesktopId))
+        if (!switched || !_vds.RemoveDesktop(entry.TempDesktop))
         {
-            _vds.RemoveDesktop(entry.TempDesktop);
-            Marshal.ReleaseComObject(entry.TempDesktop);
+            Trace.WriteLine($"FullScreenManager: Could not clean up desktop {entry.TempDesktopId}; keeping it tracked for retry.");
+            return;
         }
+
+        Marshal.ReleaseComObject(entry.TempDesktop);
+        _tracker.Untrack(hwnd);
     }
 
     /// <summary>

--- a/src/MaximizeToVirtualDesktop/FullScreenManager.cs
+++ b/src/MaximizeToVirtualDesktop/FullScreenManager.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using MaximizeToVirtualDesktop.Interop;
 
 namespace MaximizeToVirtualDesktop;
@@ -13,16 +14,18 @@ internal sealed class FullScreenManager
     private readonly VirtualDesktopService _vds;
     private readonly FullScreenTracker _tracker;
     private readonly AppSettings _settings;
+    private readonly Control _syncControl;
     private readonly HashSet<IntPtr> _inFlight = new();
     // Track temp desktop COM refs that have already been released to prevent double-release.
     // Multiple tracked windows may share the same TempDesktop COM pointer.
     private readonly HashSet<Guid> _releasedDesktops = new();
 
-    public FullScreenManager(VirtualDesktopService vds, FullScreenTracker tracker, AppSettings settings)
+    public FullScreenManager(VirtualDesktopService vds, FullScreenTracker tracker, AppSettings settings, Control syncControl)
     {
         _vds = vds;
         _tracker = tracker;
         _settings = settings;
+        _syncControl = syncControl;
     }
 
     /// <summary>
@@ -78,10 +81,7 @@ internal sealed class FullScreenManager
             return;
         }
 
-        // 1. Move only the clicked window
-        var allWindows = new List<IntPtr> { hwnd };
-
-        // 2. Record original state for all windows
+        // 1. Record original state
         var originalDesktopId = _vds.GetDesktopIdForWindow(hwnd);
         if (originalDesktopId == null)
         {
@@ -96,7 +96,7 @@ internal sealed class FullScreenManager
             return;
         }
 
-        // 3. Create new virtual desktop
+        // 2. Create new virtual desktop
         var (tempDesktop, tempDesktopId) = _vds.CreateDesktop();
         if (tempDesktop == null || tempDesktopId == null)
         {
@@ -104,7 +104,7 @@ internal sealed class FullScreenManager
             return;
         }
 
-        // 4. Name the desktop after the window title (or process name as fallback)
+        // 3. Name the desktop
         string? processName = null;
         try
         {
@@ -115,93 +115,43 @@ internal sealed class FullScreenManager
                 : process.ProcessName;
             _vds.SetDesktopName(tempDesktop, $"[MVD] {processName}");
         }
-        catch
-        {
-            // Non-critical, continue
-        }
+        catch { /* Non-critical */ }
 
-        // 5. Move all windows to new desktop
-        var movedWindows = new List<IntPtr>();
-        foreach (var window in allWindows)
+        // 4. Maximize & switch
+        bool elevated = NativeMethods.IsWindowElevated(hwnd);
+
+        if (!elevated && NativeMethods.IsWindow(hwnd))
         {
-            if (_vds.MoveWindowToDesktop(window, tempDesktop))
+            NativeMethods.ShowWindow(hwnd, NativeMethods.SW_MAXIMIZE);
+            var waitUntil = Environment.TickCount + 300;
+            while (Environment.TickCount < waitUntil)
             {
-                movedWindows.Add(window);
-            }
-            else if (window == hwnd)
-            {
-                // Primary window failed — must rollback
-                Trace.WriteLine($"FullScreenManager: Failed to move primary window {window}, rolling back.");
-                var origDesktop = _vds.FindDesktop(originalDesktopId.Value);
-                try
-                {
-                    if (origDesktop != null)
-                    {
-                        foreach (var movedWindow in movedWindows)
-                        {
-                            _vds.MoveWindowToDesktop(movedWindow, origDesktop);
-                        }
-                    }
-                }
-                finally
-                {
-                    if (origDesktop != null) Marshal.ReleaseComObject(origDesktop);
-                }
-                _vds.RemoveDesktop(tempDesktop);
-                Marshal.ReleaseComObject(tempDesktop);
-                return;
-            }
-            else
-            {
-                // Secondary window failed — skip it, not critical
-                Trace.WriteLine($"FullScreenManager: Skipping secondary window {window} (move failed).");
+                Application.DoEvents();
+                Thread.Sleep(10);
             }
         }
 
-        // 6. Switch to the new desktop
+        _vds.PinWindow(hwnd);
+
         if (!_vds.SwitchToDesktop(tempDesktop))
         {
-            // Rollback: move all windows back, remove desktop
-            Trace.WriteLine("FullScreenManager: Failed to switch desktop, rolling back.");
-            var origDesktop = _vds.FindDesktop(originalDesktopId.Value);
-            try
-            {
-                if (origDesktop != null)
-                {
-                    foreach (var window in movedWindows)
-                    {
-                        _vds.MoveWindowToDesktop(window, origDesktop);
-                    }
-                }
-            }
-            finally
-            {
-                if (origDesktop != null) Marshal.ReleaseComObject(origDesktop);
-            }
-            _vds.RemoveDesktop(tempDesktop);
-            Marshal.ReleaseComObject(tempDesktop);
+            _vds.UnpinWindow(hwnd);
+            RollbackSwitch(tempDesktop, originalDesktopId.Value, hwnd, originalPlacement, elevated);
             return;
         }
 
-        // 7. Maximize the primary window — delay lets desktop switch animation finish first
-        bool elevated = NativeMethods.IsWindowElevated(hwnd);
-        if (elevated)
+        if (!_vds.MoveWindowToDesktop(hwnd, tempDesktop))
         {
-            Trace.WriteLine("FullScreenManager: Window is elevated, cannot maximize via UIPI.");
-            if (_settings.ShowSwitchPopup)
-            {
-                NotificationOverlay.ShowNotification("⚠ Elevated Window",
-                    "Press Win+↑ to maximize", hwnd);
-            }
+            _vds.UnpinWindow(hwnd);
+            RollbackSwitch(tempDesktop, originalDesktopId.Value, hwnd, originalPlacement, elevated);
+            return;
         }
-        else
-        {
-            Thread.Sleep(250);
-            NativeMethods.ShowWindow(hwnd, NativeMethods.SW_MAXIMIZE);
-        }
-        NativeMethods.SetForegroundWindow(hwnd);
 
-        // 8. Track the window
+        _vds.UnpinWindow(hwnd);
+
+        ScheduleFocusRetry(hwnd, 4);
+
+        // 5. Track
         _tracker.Track(hwnd, originalDesktopId.Value, tempDesktopId.Value, tempDesktop, processName, originalPlacement);
 
         if (_settings.ShowSwitchPopup)
@@ -212,10 +162,73 @@ internal sealed class FullScreenManager
     }
 
     /// <summary>
+    /// Retry SetForegroundWindow using AttachThreadInput to yield focus
+    /// without sending synthetic keystrokes that could trigger UI side effects (e.g. Word ribbon).
+    /// </summary>
+    private void ScheduleFocusRetry(IntPtr hwnd, int attempts)
+    {
+        _ = Task.Run(async () =>
+        {
+            for (int i = 0; i < attempts; i++)
+            {
+                await Task.Delay(80);
+                if (!_syncControl.IsDisposed && _syncControl.IsHandleCreated)
+                {
+                    try
+                    {
+                        _syncControl.BeginInvoke(() =>
+                        {
+                            if (NativeMethods.IsWindow(hwnd))
+                            {
+                                uint targetThread = NativeMethods.GetWindowThreadProcessId(hwnd, out _);
+                                uint currentThread = NativeMethods.GetCurrentThreadId();
+                                NativeMethods.AttachThreadInput(targetThread, currentThread, true);
+                                try
+                                {
+                                    NativeMethods.SetForegroundWindow(hwnd);
+                                    NativeMethods.SetFocus(hwnd);
+                                }
+                                finally
+                                {
+                                    NativeMethods.AttachThreadInput(targetThread, currentThread, false);
+                                }
+                            }
+                        });
+                    }
+                    catch (ObjectDisposedException) { break; }
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Rollback a failed desktop switch: restore window placement, move windows back, remove temp desktop.
+    /// </summary>
+    private void RollbackSwitch(IVirtualDesktop tempDesktop, Guid originalDesktopId,
+        IntPtr hwnd, NativeMethods.WINDOWPLACEMENT originalPlacement, bool elevated)
+    {
+        Trace.WriteLine("FullScreenManager: Failed desktop switch, rolling back.");
+        if (!elevated && NativeMethods.IsWindow(hwnd))
+        {
+            var p = originalPlacement;
+            NativeMethods.SetWindowPlacement(hwnd, ref p);
+        }
+        var origDesktop = _vds.FindDesktop(originalDesktopId);
+        try
+        {
+            if (origDesktop != null) _vds.MoveWindowToDesktop(hwnd, origDesktop);
+        }
+        finally { if (origDesktop != null) Marshal.ReleaseComObject(origDesktop); }
+        _vds.RemoveDesktop(tempDesktop);
+        Marshal.ReleaseComObject(tempDesktop);
+    }
+
+    /// <summary>
     /// Restore a tracked window: move it back to its original desktop, restore window state,
     /// switch back, and remove the temp desktop.
+    /// When <paramref name="keepMinimized"/> is true, the window stays minimized (only desktop cleanup is performed).
     /// </summary>
-    public void Restore(IntPtr hwnd)
+    public void Restore(IntPtr hwnd, bool keepMinimized = false)
     {
         var entry = _tracker.Get(hwnd);
         if (entry == null)
@@ -231,29 +244,24 @@ internal sealed class FullScreenManager
         var origDesktop = _vds.FindDesktop(entry.OriginalDesktopId);
         try
         {
-            // Restore window placement
-            if (NativeMethods.IsWindow(hwnd))
-            {
-                var placement = entry.OriginalPlacement;
-                NativeMethods.SetWindowPlacement(hwnd, ref placement);
-                // Ensure the window is shown in its normal (not maximized) state
-                NativeMethods.ShowWindow(hwnd, (int)NativeMethods.SW_SHOWNORMAL);
-            }
+            _vds.PinWindow(hwnd);
 
-            // Move window back to original desktop
+            if (origDesktop != null) _vds.SwitchToDesktop(origDesktop);
             if (origDesktop != null && NativeMethods.IsWindow(hwnd))
-            {
                 _vds.MoveWindowToDesktop(hwnd, origDesktop);
-            }
 
-            // Switch back to original desktop
-            if (origDesktop != null)
+            _vds.UnpinWindow(hwnd);
+
+            if (!keepMinimized && NativeMethods.IsWindow(hwnd))
             {
-                _vds.SwitchToDesktop(origDesktop);
-            }
-            else
-            {
-                Trace.WriteLine("FullScreenManager: Original desktop no longer exists, leaving window on current.");
+                var cur = NativeMethods.WINDOWPLACEMENT.Default;
+                if (NativeMethods.GetWindowPlacement(hwnd, ref cur)
+                    && cur.showCmd == NativeMethods.SW_MAXIMIZE)
+                {
+                    var placement = entry.OriginalPlacement;
+                    NativeMethods.SetWindowPlacement(hwnd, ref placement);
+                }
+                NativeMethods.ShowWindow(hwnd, (int)NativeMethods.SW_SHOWNORMAL);
             }
         }
         finally
@@ -270,10 +278,11 @@ internal sealed class FullScreenManager
       
         _tracker.Untrack(hwnd);
 
-        // Set focus on the restored window
-        if (NativeMethods.IsWindow(hwnd))
+        // Set focus on the restored window (skip if minimized)
+        if (!keepMinimized && NativeMethods.IsWindow(hwnd))
         {
             NativeMethods.SetForegroundWindow(hwnd);
+            ScheduleFocusRetry(hwnd, 2);
         }
 
         if (_settings.ShowSwitchPopup)

--- a/src/MaximizeToVirtualDesktop/Interop/DesktopManagerAdapter.cs
+++ b/src/MaximizeToVirtualDesktop/Interop/DesktopManagerAdapter.cs
@@ -14,7 +14,7 @@ internal abstract class DesktopManagerAdapter : IDisposable
     public abstract IVirtualDesktop CreateDesktop();
     public abstract void MoveViewToDesktop(IApplicationView view, IVirtualDesktop desktop);
     public abstract int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop);
-    public abstract void SwitchDesktopWithAnimation(IVirtualDesktop desktop);
+    public abstract void SwitchDesktop(IVirtualDesktop desktop);
     public abstract void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback);
     public abstract IVirtualDesktop FindDesktop(ref Guid desktopId);
     public abstract void SetDesktopName(IVirtualDesktop desktop, IntPtr nameHString);
@@ -109,8 +109,8 @@ internal abstract class DesktopManagerAdapter : IDisposable
             => _com!.MoveViewToDesktop(view, desktop);
         public override int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop)
             => _com!.GetAdjacentDesktop(from, direction, out desktop);
-        public override void SwitchDesktopWithAnimation(IVirtualDesktop desktop)
-            => _com!.SwitchDesktopWithAnimation(desktop);
+        public override void SwitchDesktop(IVirtualDesktop desktop)
+            => _com!.SwitchDesktop(desktop);
         public override void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback)
             => _com!.RemoveDesktop(desktop, fallback);
         public override IVirtualDesktop FindDesktop(ref Guid desktopId)
@@ -138,8 +138,8 @@ internal abstract class DesktopManagerAdapter : IDisposable
             => _com!.MoveViewToDesktop(view, desktop);
         public override int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop)
             => _com!.GetAdjacentDesktop(from, direction, out desktop);
-        public override void SwitchDesktopWithAnimation(IVirtualDesktop desktop)
-            => _com!.SwitchDesktopWithAnimation(desktop);
+        public override void SwitchDesktop(IVirtualDesktop desktop)
+            => _com!.SwitchDesktop(desktop);
         public override void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback)
             => _com!.RemoveDesktop(desktop, fallback);
         public override IVirtualDesktop FindDesktop(ref Guid desktopId)

--- a/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
+++ b/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
@@ -49,6 +49,11 @@ internal static partial class NativeMethods
     internal static extern IntPtr WindowFromPoint(POINT point);
 
     [DllImport("user32.dll")]
+    internal static extern IntPtr GetAncestor(IntPtr hwnd, uint gaFlags);
+
+    internal const uint GA_ROOT = 2;
+
+    [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
@@ -72,15 +77,6 @@ internal static partial class NativeMethods
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool IsIconic(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    internal static extern uint GetDoubleClickTime();
-
-    [DllImport("user32.dll")]
-    internal static extern int GetSystemMetrics(int nIndex);
-
-    [DllImport("user32.dll")]
-    internal static extern IntPtr SetFocus(IntPtr hWnd);
 
     internal const int VK_LBUTTON = 0x01;
 
@@ -197,7 +193,10 @@ internal static partial class NativeMethods
     internal const int SW_MAXIMIZE = 3;
     internal const int SW_RESTORE = 9;
     internal const int SW_MINIMIZE = 6;
+    internal const uint SW_HIDE = 0;
+    internal const uint SW_SHOWMINNOACTIVE = 7;
     internal const int SW_SHOWNOACTIVATE = 4;
+    internal const uint WPF_RESTORETOMAXIMIZED = 0x0002;
 
     internal const uint WM_HOTKEY = 0x0312;
     internal const uint WM_NCHITTEST = 0x0084;
@@ -207,12 +206,6 @@ internal static partial class NativeMethods
     internal static readonly IntPtr SC_MAXIMIZE = new IntPtr(0xF030);
 
     internal const int HTMAXBUTTON = 9;
-    internal const int HTCAPTION = 2;
-    internal const int HTSYSMENU = 3;
-    internal const int HTMENU = 5;
-
-    internal const int SM_CXDOUBLECLK = 36;
-    internal const int SM_CYDOUBLECLK = 37;
 
     internal const int WH_MOUSE_LL = 14;
     internal const int HC_ACTION = 0;

--- a/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
+++ b/src/MaximizeToVirtualDesktop/Interop/NativeMethods.cs
@@ -69,6 +69,21 @@ internal static partial class NativeMethods
     [DllImport("user32.dll")]
     internal static extern short GetAsyncKeyState(int vKey);
 
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    internal static extern uint GetDoubleClickTime();
+
+    [DllImport("user32.dll")]
+    internal static extern int GetSystemMetrics(int nIndex);
+
+    [DllImport("user32.dll")]
+    internal static extern IntPtr SetFocus(IntPtr hWnd);
+
+    internal const int VK_LBUTTON = 0x01;
+
     [DllImport("kernel32.dll")]
     internal static extern uint GetCurrentThreadId();
 
@@ -192,6 +207,12 @@ internal static partial class NativeMethods
     internal static readonly IntPtr SC_MAXIMIZE = new IntPtr(0xF030);
 
     internal const int HTMAXBUTTON = 9;
+    internal const int HTCAPTION = 2;
+    internal const int HTSYSMENU = 3;
+    internal const int HTMENU = 5;
+
+    internal const int SM_CXDOUBLECLK = 36;
+    internal const int SM_CYDOUBLECLK = 37;
 
     internal const int WH_MOUSE_LL = 14;
     internal const int HC_ACTION = 0;
@@ -209,6 +230,7 @@ internal static partial class NativeMethods
 
     internal const uint WINEVENT_OUTOFCONTEXT = 0x0000;
     internal const uint EVENT_OBJECT_DESTROY = 0x8001;
+    internal const uint EVENT_OBJECT_HIDE = 0x8003;
     internal const uint EVENT_SYSTEM_MOVESIZEEND = 0x000B;
     internal const uint EVENT_OBJECT_LOCATIONCHANGE = 0x800B;
 

--- a/src/MaximizeToVirtualDesktop/MaximizeButtonHook.cs
+++ b/src/MaximizeToVirtualDesktop/MaximizeButtonHook.cs
@@ -5,8 +5,8 @@ using MaximizeToVirtualDesktop.Interop;
 namespace MaximizeToVirtualDesktop;
 
 /// <summary>
-/// Low-level mouse hook that detects Shift+Click on a window's maximize button.
-/// Works wherever Windows 11 Snap Layouts works (apps that return HTMAXBUTTON from WM_NCHITTEST).
+/// Low-level mouse hook that intercepts maximize button clicks and title-bar double-clicks.
+/// Suppresses the Windows maximize and triggers virtual-desktop maximize instead.
 /// </summary>
 internal sealed class MaximizeButtonHook : IDisposable
 {
@@ -18,6 +18,17 @@ internal sealed class MaximizeButtonHook : IDisposable
 
     // Must be stored as a field to prevent GC collection
     private readonly NativeMethods.LowLevelHookProc _hookProc;
+
+    // Double-click tracking
+    private long _lastClickTicks;
+    private int _lastClickX;
+    private int _lastClickY;
+    private IntPtr _lastClickHwnd;
+
+    // System metrics (cached)
+    private static readonly int DoubleClickTimeMs = (int)NativeMethods.GetDoubleClickTime();
+    private static readonly int DoubleClickWidth = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK);
+    private static readonly int DoubleClickHeight = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK);
 
     public MaximizeButtonHook(FullScreenManager manager, Control syncControl, AppSettings settings)
     {
@@ -51,38 +62,48 @@ internal sealed class MaximizeButtonHook : IDisposable
     {
         if (nCode >= NativeMethods.HC_ACTION && wParam == (IntPtr)NativeMethods.WM_LBUTTONDOWN)
         {
-            bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
-            // Normal mode:   Shift+Click  → virtual desktop
-            // Inverted mode: plain Click  → virtual desktop; Shift+Click → normal maximize
-            bool triggerVirtualDesktop = _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
+            if (!IsTriggerActive()) return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
 
-            if (triggerVirtualDesktop)
+            var hookStruct = Marshal.PtrToStructure<NativeMethods.MSLLHOOKSTRUCT>(lParam);
+            var hwnd = NativeMethods.WindowFromPoint(hookStruct.pt);
+
+            if (hwnd != IntPtr.Zero)
             {
-                var hookStruct = Marshal.PtrToStructure<NativeMethods.MSLLHOOKSTRUCT>(lParam);
-                var hwnd = NativeMethods.WindowFromPoint(hookStruct.pt);
-
-                if (hwnd != IntPtr.Zero && IsClickOnMaximizeButton(hwnd, hookStruct.pt))
+                if (IsClickOnMaximizeButton(hwnd, hookStruct.pt))
                 {
-                    // Find the top-level window (the click target might be a child)
-                    var topLevel = GetTopLevelWindow(hwnd);
-                    if (topLevel != IntPtr.Zero)
+                    var buttonTopLevel = GetTopLevelWindow(hwnd);
+                    if (buttonTopLevel != IntPtr.Zero)
                     {
-                        // Post to UI thread — COM calls cannot be made inside an input-synchronous hook
-                        try
-                        {
-                            if (!_syncControl.IsDisposed && _syncControl.IsHandleCreated)
-                            {
-                                _syncControl.BeginInvoke(() => _manager.Toggle(topLevel));
-                            }
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // App is shutting down
-                        }
-
-                        // Suppress the click
+                        PostToggle(buttonTopLevel);
                         return (IntPtr)1;
                     }
+                }
+
+                // Title-bar double-click
+                var nowTicks = DateTime.UtcNow.Ticks;
+                var elapsedMs = (nowTicks - _lastClickTicks) / TimeSpan.TicksPerMillisecond;
+                var topLevel = GetTopLevelWindow(hwnd);
+                var lastTopLevel = _lastClickHwnd != IntPtr.Zero
+                    ? GetTopLevelWindow(_lastClickHwnd) : IntPtr.Zero;
+
+                if (elapsedMs > 0 && elapsedMs < DoubleClickTimeMs &&
+                    Math.Abs(hookStruct.pt.X - _lastClickX) < DoubleClickWidth &&
+                    Math.Abs(hookStruct.pt.Y - _lastClickY) < DoubleClickHeight &&
+                    topLevel != IntPtr.Zero && topLevel == lastTopLevel)
+                {
+                    if (IsClickOnCaption(hwnd, hookStruct.pt))
+                    {
+                        _lastClickTicks = 0;
+                        PostToggle(topLevel);
+                        return (IntPtr)1;
+                    }
+                }
+                else
+                {
+                    _lastClickTicks = nowTicks;
+                    _lastClickX = hookStruct.pt.X;
+                    _lastClickY = hookStruct.pt.Y;
+                    _lastClickHwnd = hwnd;
                 }
             }
         }
@@ -90,17 +111,54 @@ internal sealed class MaximizeButtonHook : IDisposable
         return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
     }
 
+    private bool IsTriggerActive()
+    {
+        bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
+        return _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
+    }
+
+    private void PostToggle(IntPtr topLevel)
+    {
+        try
+        {
+            if (!_syncControl.IsDisposed && _syncControl.IsHandleCreated)
+            {
+                _syncControl.BeginInvoke(() => _manager.Toggle(topLevel));
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // App is shutting down
+        }
+    }
+
     private static bool IsClickOnMaximizeButton(IntPtr hwnd, NativeMethods.POINT pt)
     {
         try
         {
-            // Use SendMessageTimeout to avoid blocking if the target window is hung.
-            // A hung window would cause Windows to silently remove our LL hook.
             IntPtr lParam = (IntPtr)((pt.Y << 16) | (pt.X & 0xFFFF));
             IntPtr result = NativeMethods.SendMessageTimeout(
                 hwnd, NativeMethods.WM_NCHITTEST, IntPtr.Zero, lParam,
                 NativeMethods.SMTO_ABORTIFHUNG, 100, out IntPtr hitResult);
             return result != IntPtr.Zero && hitResult == (IntPtr)NativeMethods.HTMAXBUTTON;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsClickOnCaption(IntPtr hwnd, NativeMethods.POINT pt)
+    {
+        try
+        {
+            IntPtr lParam = (IntPtr)((pt.Y << 16) | (pt.X & 0xFFFF));
+            IntPtr result = NativeMethods.SendMessageTimeout(
+                hwnd, NativeMethods.WM_NCHITTEST, IntPtr.Zero, lParam,
+                NativeMethods.SMTO_ABORTIFHUNG, 50, out IntPtr hitResult);
+            if (result == IntPtr.Zero) return false;
+            var hit = hitResult.ToInt32();
+            return hit == NativeMethods.HTCAPTION || hit == NativeMethods.HTSYSMENU || hit == NativeMethods.HTMENU;
         }
         catch
         {

--- a/src/MaximizeToVirtualDesktop/MaximizeButtonHook.cs
+++ b/src/MaximizeToVirtualDesktop/MaximizeButtonHook.cs
@@ -5,7 +5,7 @@ using MaximizeToVirtualDesktop.Interop;
 namespace MaximizeToVirtualDesktop;
 
 /// <summary>
-/// Low-level mouse hook that intercepts maximize button clicks and title-bar double-clicks.
+/// Low-level mouse hook that detects Shift+Click on a window's maximize button.
 /// Suppresses the Windows maximize and triggers virtual-desktop maximize instead.
 /// </summary>
 internal sealed class MaximizeButtonHook : IDisposable
@@ -18,17 +18,6 @@ internal sealed class MaximizeButtonHook : IDisposable
 
     // Must be stored as a field to prevent GC collection
     private readonly NativeMethods.LowLevelHookProc _hookProc;
-
-    // Double-click tracking
-    private long _lastClickTicks;
-    private int _lastClickX;
-    private int _lastClickY;
-    private IntPtr _lastClickHwnd;
-
-    // System metrics (cached)
-    private static readonly int DoubleClickTimeMs = (int)NativeMethods.GetDoubleClickTime();
-    private static readonly int DoubleClickWidth = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK);
-    private static readonly int DoubleClickHeight = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK);
 
     public MaximizeButtonHook(FullScreenManager manager, Control syncControl, AppSettings settings)
     {
@@ -62,48 +51,18 @@ internal sealed class MaximizeButtonHook : IDisposable
     {
         if (nCode >= NativeMethods.HC_ACTION && wParam == (IntPtr)NativeMethods.WM_LBUTTONDOWN)
         {
-            if (!IsTriggerActive()) return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
-
-            var hookStruct = Marshal.PtrToStructure<NativeMethods.MSLLHOOKSTRUCT>(lParam);
-            var hwnd = NativeMethods.WindowFromPoint(hookStruct.pt);
-
-            if (hwnd != IntPtr.Zero)
+            if (IsTriggerActive())
             {
-                if (IsClickOnMaximizeButton(hwnd, hookStruct.pt))
+                var hookStruct = Marshal.PtrToStructure<NativeMethods.MSLLHOOKSTRUCT>(lParam);
+                var hwnd = NativeMethods.WindowFromPoint(hookStruct.pt);
+                if (hwnd != IntPtr.Zero && IsClickOnMaximizeButton(hwnd, hookStruct.pt))
                 {
-                    var buttonTopLevel = GetTopLevelWindow(hwnd);
-                    if (buttonTopLevel != IntPtr.Zero)
+                    var topLevel = NativeMethods.GetAncestor(hwnd, NativeMethods.GA_ROOT);
+                    if (topLevel != IntPtr.Zero)
                     {
-                        PostToggle(buttonTopLevel);
-                        return (IntPtr)1;
-                    }
-                }
-
-                // Title-bar double-click
-                var nowTicks = DateTime.UtcNow.Ticks;
-                var elapsedMs = (nowTicks - _lastClickTicks) / TimeSpan.TicksPerMillisecond;
-                var topLevel = GetTopLevelWindow(hwnd);
-                var lastTopLevel = _lastClickHwnd != IntPtr.Zero
-                    ? GetTopLevelWindow(_lastClickHwnd) : IntPtr.Zero;
-
-                if (elapsedMs > 0 && elapsedMs < DoubleClickTimeMs &&
-                    Math.Abs(hookStruct.pt.X - _lastClickX) < DoubleClickWidth &&
-                    Math.Abs(hookStruct.pt.Y - _lastClickY) < DoubleClickHeight &&
-                    topLevel != IntPtr.Zero && topLevel == lastTopLevel)
-                {
-                    if (IsClickOnCaption(hwnd, hookStruct.pt))
-                    {
-                        _lastClickTicks = 0;
                         PostToggle(topLevel);
                         return (IntPtr)1;
                     }
-                }
-                else
-                {
-                    _lastClickTicks = nowTicks;
-                    _lastClickX = hookStruct.pt.X;
-                    _lastClickY = hookStruct.pt.Y;
-                    _lastClickHwnd = hwnd;
                 }
             }
         }
@@ -147,39 +106,6 @@ internal sealed class MaximizeButtonHook : IDisposable
             return false;
         }
     }
-
-    private static bool IsClickOnCaption(IntPtr hwnd, NativeMethods.POINT pt)
-    {
-        try
-        {
-            IntPtr lParam = (IntPtr)((pt.Y << 16) | (pt.X & 0xFFFF));
-            IntPtr result = NativeMethods.SendMessageTimeout(
-                hwnd, NativeMethods.WM_NCHITTEST, IntPtr.Zero, lParam,
-                NativeMethods.SMTO_ABORTIFHUNG, 50, out IntPtr hitResult);
-            if (result == IntPtr.Zero) return false;
-            var hit = hitResult.ToInt32();
-            return hit == NativeMethods.HTCAPTION || hit == NativeMethods.HTSYSMENU || hit == NativeMethods.HTMENU;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static IntPtr GetTopLevelWindow(IntPtr hwnd)
-    {
-        // Walk up the parent chain to find the top-level window
-        IntPtr current = hwnd;
-        IntPtr parent;
-        while ((parent = GetParent(current)) != IntPtr.Zero)
-        {
-            current = parent;
-        }
-        return current;
-    }
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetParent(IntPtr hWnd);
 
     public void Dispose()
     {

--- a/src/MaximizeToVirtualDesktop/TrayApplication.cs
+++ b/src/MaximizeToVirtualDesktop/TrayApplication.cs
@@ -47,7 +47,7 @@ internal sealed class TrayApplication : Form
         // Initialize components
         _vds = new VirtualDesktopService();
         _tracker = new FullScreenTracker();
-        _manager = new FullScreenManager(_vds, _tracker, _settings);
+        _manager = new FullScreenManager(_vds, _tracker, _settings, this);
         _monitor = new WindowMonitor(_manager, _tracker, this, _settings);
         _mouseHook = new MaximizeButtonHook(_manager, this, _settings);
 

--- a/src/MaximizeToVirtualDesktop/TrayApplication.cs
+++ b/src/MaximizeToVirtualDesktop/TrayApplication.cs
@@ -47,7 +47,7 @@ internal sealed class TrayApplication : Form
         // Initialize components
         _vds = new VirtualDesktopService();
         _tracker = new FullScreenTracker();
-        _manager = new FullScreenManager(_vds, _tracker, _settings, this);
+        _manager = new FullScreenManager(_vds, _tracker, _settings);
         _monitor = new WindowMonitor(_manager, _tracker, this, _settings);
         _mouseHook = new MaximizeButtonHook(_manager, this, _settings);
 

--- a/src/MaximizeToVirtualDesktop/VirtualDesktopService.cs
+++ b/src/MaximizeToVirtualDesktop/VirtualDesktopService.cs
@@ -197,27 +197,7 @@ internal sealed class VirtualDesktopService : IDisposable
     {
         try
         {
-            // Activate the taskbar to prevent flashing icons (from MScholtes)
-            var taskbarHwnd = NativeMethods.FindWindow("Shell_TrayWnd", null);
-            if (taskbarHwnd != IntPtr.Zero)
-            {
-                NativeMethods.GetWindowThreadProcessId(taskbarHwnd, out _);
-                var foregroundHwnd = NativeMethods.GetForegroundWindow();
-                uint desktopThreadId = NativeMethods.GetWindowThreadProcessId(taskbarHwnd, out _);
-                uint foregroundThreadId = NativeMethods.GetWindowThreadProcessId(foregroundHwnd, out _);
-                uint currentThreadId = NativeMethods.GetCurrentThreadId();
-
-                if (desktopThreadId != 0 && foregroundThreadId != 0 && foregroundThreadId != currentThreadId)
-                {
-                    NativeMethods.AttachThreadInput(desktopThreadId, currentThreadId, true);
-                    NativeMethods.AttachThreadInput(foregroundThreadId, currentThreadId, true);
-                    NativeMethods.SetForegroundWindow(taskbarHwnd);
-                    NativeMethods.AttachThreadInput(foregroundThreadId, currentThreadId, false);
-                    NativeMethods.AttachThreadInput(desktopThreadId, currentThreadId, false);
-                }
-            }
-
-            _managerInternal!.SwitchDesktopWithAnimation(desktop);
+            _managerInternal!.SwitchDesktop(desktop);
 
             Trace.WriteLine($"VirtualDesktopService: Switched to desktop {desktop.GetId()}");
             return true;

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -17,15 +17,16 @@ internal sealed class WindowMonitor : IDisposable
     private readonly AppSettings _settings;
     private IntPtr _locationChangeHook;
     private IntPtr _destroyHook;
+    private IntPtr _hideHook;
     private bool _disposed;
 
     // Must be stored as fields to prevent GC collection of the delegate
     private readonly NativeMethods.WinEventProc _locationChangeProc;
     private readonly NativeMethods.WinEventProc _destroyProc;
+    private readonly NativeMethods.WinEventProc _hideProc;
     private readonly NativeMethods.WinEventProc _moveSizeEndProc;
     private IntPtr _moveSizeEndHook;
     // Track windows that have been maximized but need to wait for resize end
-    // Access to this set must happen only on the UI thread.
     private readonly HashSet<IntPtr> _pendingMaximize = new();
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl, AppSettings settings)
@@ -37,6 +38,7 @@ internal sealed class WindowMonitor : IDisposable
 
         _locationChangeProc = OnLocationChange;
         _destroyProc = OnDestroy;
+        _hideProc = OnHide;
         _moveSizeEndProc = OnMoveSizeEnd;
     }
 
@@ -65,6 +67,13 @@ internal sealed class WindowMonitor : IDisposable
             IntPtr.Zero, _destroyProc,
             0, 0, NativeMethods.WINEVENT_OUTOFCONTEXT);
 
+        // EVENT_OBJECT_HIDE fires when a window is hidden (closed to tray, or closing)
+        _hideHook = NativeMethods.SetWinEventHook(
+            NativeMethods.EVENT_OBJECT_HIDE,
+            NativeMethods.EVENT_OBJECT_HIDE,
+            IntPtr.Zero, _hideProc,
+            0, 0, NativeMethods.WINEVENT_OUTOFCONTEXT);
+
         if (_locationChangeHook == IntPtr.Zero || _destroyHook == IntPtr.Zero)
         {
             Trace.WriteLine("WindowMonitor: Failed to set one or more WinEvent hooks.");
@@ -73,6 +82,12 @@ internal sealed class WindowMonitor : IDisposable
         {
             Trace.WriteLine("WindowMonitor: Started monitoring.");
         }
+    }
+
+    private bool ShouldTriggerVirtualDesktop()
+    {
+        bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
+        return _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
     }
 
     private void OnLocationChange(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
@@ -89,8 +104,14 @@ internal sealed class WindowMonitor : IDisposable
             {
                 if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
                 {
-                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} restored via location change.");
-                    MarshalToUiThread(() => _manager.Restore(hwnd));
+                    // If left mouse button is down, user is dragging — let Windows handle the resize.
+                    // OnMoveSizeEnd will fire after release and trigger restore.
+                    bool isDragging = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_LBUTTON) & 0x8000) != 0;
+                    if (isDragging) return;
+
+                    bool isMinimized = NativeMethods.IsIconic(hwnd);
+                    Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} un-maximized (minimized={isMinimized}).");
+                    MarshalToUiThread(() => _manager.Restore(hwnd, keepMinimized: isMinimized));
                     return;
                 }
             }
@@ -103,8 +124,7 @@ internal sealed class WindowMonitor : IDisposable
         if (!NativeMethods.GetWindowPlacement(hwnd, ref newPlacement)) return;
         if (newPlacement.showCmd != NativeMethods.SW_MAXIMIZE) return;
 
-        bool shiftHeld = (NativeMethods.GetAsyncKeyState(NativeMethods.VK_SHIFT) & 0x8000) != 0;
-        bool triggerVirtualDesktop = _settings.InvertShiftClick ? !shiftHeld : shiftHeld;
+        bool triggerVirtualDesktop = ShouldTriggerVirtualDesktop();
         if (triggerVirtualDesktop)
         {
             // Defer maximization until after the resize operation completes
@@ -116,24 +136,30 @@ internal sealed class WindowMonitor : IDisposable
                     // Schedule a fallback in case MoveSizeEnd does not fire (e.g., keyboard shortcut)
                     _ = Task.Run(async () =>
                     {
-                        await Task.Delay(200);
+                        await Task.Delay(50);
                         // Marshal the check/remove back onto the UI thread
                         MarshalToUiThread(() =>
                         {
                             if (_pendingMaximize.Contains(hwnd))
                             {
                                 _pendingMaximize.Remove(hwnd);
+                                // If already tracked, the hook path already handled it — don't double-trigger
+                                if (_tracker.IsTracked(hwnd))
+                                {
+                                    Trace.WriteLine($"WindowMonitor: Pending window {hwnd} already tracked, skipping fallback.");
+                                    return;
+                                }
                                 var placement = NativeMethods.WINDOWPLACEMENT.Default;
                                 bool isMaximized = NativeMethods.GetWindowPlacement(hwnd, ref placement) && placement.showCmd == NativeMethods.SW_MAXIMIZE;
                                 if (isMaximized)
                                 {
                                     Trace.WriteLine($"WindowMonitor: Fallback processing for pending maximize window {hwnd}.");
-                                    _manager.MaximizeToDesktop(hwnd);
+                                    _manager.Toggle(hwnd);
                                 }
                                 else
                                 {
                                     Trace.WriteLine($"WindowMonitor: Fallback detected restore for pending window {hwnd}.");
-                                    _manager.Restore(hwnd);
+                                    _manager.Restore(hwnd, keepMinimized: NativeMethods.IsIconic(hwnd));
                                 }
                             }
                         });
@@ -158,7 +184,7 @@ internal sealed class WindowMonitor : IDisposable
         if (wasPending)
         {
             Trace.WriteLine($"WindowMonitor: MoveSizeEnd triggered for pending maximize window {hwnd}.");
-            MarshalToUiThread(() => _manager.MaximizeToDesktop(hwnd));
+            MarshalToUiThread(() => _manager.Toggle(hwnd));
             return;
         }
 
@@ -167,7 +193,7 @@ internal sealed class WindowMonitor : IDisposable
         var placement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref placement)) return;
         Trace.WriteLine($"WindowMonitor: MoveSizeEnd: tracked window {hwnd} showCmd={placement.showCmd}.");
-        if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
+        if (placement.showCmd != NativeMethods.SW_MAXIMIZE && !NativeMethods.IsIconic(hwnd))
         {
             Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} un-maximized via move/size, restoring.");
             await Task.Delay(100);
@@ -182,6 +208,16 @@ internal sealed class WindowMonitor : IDisposable
         if (!_tracker.IsTracked(hwnd)) return;
 
         Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} destroyed.");
+        MarshalToUiThread(() => _manager.HandleWindowDestroyed(hwnd));
+    }
+
+    private void OnHide(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
+        int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
+    {
+        if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
+        if (!_tracker.IsTracked(hwnd)) return;
+
+        Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} hidden, cleaning up.");
         MarshalToUiThread(() => _manager.HandleWindowDestroyed(hwnd));
     }
 
@@ -213,6 +249,11 @@ internal sealed class WindowMonitor : IDisposable
         {
             NativeMethods.UnhookWinEvent(_destroyHook);
             _destroyHook = IntPtr.Zero;
+        }
+        if (_hideHook != IntPtr.Zero)
+        {
+            NativeMethods.UnhookWinEvent(_hideHook);
+            _hideHook = IntPtr.Zero;
         }
         if (_moveSizeEndHook != IntPtr.Zero)
         {

--- a/src/MaximizeToVirtualDesktop/WindowMonitor.cs
+++ b/src/MaximizeToVirtualDesktop/WindowMonitor.cs
@@ -28,6 +28,8 @@ internal sealed class WindowMonitor : IDisposable
     private IntPtr _moveSizeEndHook;
     // Track windows that have been maximized but need to wait for resize end
     private readonly HashSet<IntPtr> _pendingMaximize = new();
+    private readonly Dictionary<IntPtr, long> _pendingHide = new();
+    private readonly System.Windows.Forms.Timer _hideTimer;
 
     public WindowMonitor(FullScreenManager manager, FullScreenTracker tracker, Control syncControl, AppSettings settings)
     {
@@ -40,6 +42,9 @@ internal sealed class WindowMonitor : IDisposable
         _destroyProc = OnDestroy;
         _hideProc = OnHide;
         _moveSizeEndProc = OnMoveSizeEnd;
+
+        _hideTimer = new System.Windows.Forms.Timer { Interval = 100 };
+        _hideTimer.Tick += (_, _) => ProcessPendingHides();
     }
 
     public void Start()
@@ -74,7 +79,8 @@ internal sealed class WindowMonitor : IDisposable
             IntPtr.Zero, _hideProc,
             0, 0, NativeMethods.WINEVENT_OUTOFCONTEXT);
 
-        if (_locationChangeHook == IntPtr.Zero || _destroyHook == IntPtr.Zero)
+        if (_locationChangeHook == IntPtr.Zero || _moveSizeEndHook == IntPtr.Zero
+            || _destroyHook == IntPtr.Zero || _hideHook == IntPtr.Zero)
         {
             Trace.WriteLine("WindowMonitor: Failed to set one or more WinEvent hooks.");
         }
@@ -193,11 +199,11 @@ internal sealed class WindowMonitor : IDisposable
         var placement = NativeMethods.WINDOWPLACEMENT.Default;
         if (!NativeMethods.GetWindowPlacement(hwnd, ref placement)) return;
         Trace.WriteLine($"WindowMonitor: MoveSizeEnd: tracked window {hwnd} showCmd={placement.showCmd}.");
-        if (placement.showCmd != NativeMethods.SW_MAXIMIZE && !NativeMethods.IsIconic(hwnd))
+        if (placement.showCmd != NativeMethods.SW_MAXIMIZE)
         {
             Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} un-maximized via move/size, restoring.");
             await Task.Delay(100);
-            MarshalToUiThread(() => _manager.Restore(hwnd));
+            MarshalToUiThread(() => _manager.Restore(hwnd, keepMinimized: NativeMethods.IsIconic(hwnd)));
         }
     }
 
@@ -208,7 +214,11 @@ internal sealed class WindowMonitor : IDisposable
         if (!_tracker.IsTracked(hwnd)) return;
 
         Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} destroyed.");
-        MarshalToUiThread(() => _manager.HandleWindowDestroyed(hwnd));
+        MarshalToUiThread(() =>
+        {
+            _pendingHide.Remove(hwnd);
+            _manager.HandleWindowDestroyed(hwnd);
+        });
     }
 
     private void OnHide(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
@@ -217,13 +227,46 @@ internal sealed class WindowMonitor : IDisposable
         if (idObject != NativeMethods.OBJID_WINDOW || idChild != 0) return;
         if (!_tracker.IsTracked(hwnd)) return;
 
-        Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} hidden, cleaning up.");
-        MarshalToUiThread(() => _manager.HandleWindowDestroyed(hwnd));
+        MarshalToUiThread(() =>
+        {
+            _pendingHide[hwnd] = Environment.TickCount64 + 300;
+            _hideTimer.Start();
+        });
+    }
+
+    private void ProcessPendingHides()
+    {
+        var now = Environment.TickCount64;
+        var due = _pendingHide
+            .Where(item => item.Value <= now)
+            .Select(item => item.Key)
+            .ToList();
+
+        foreach (var hwnd in due)
+        {
+            _pendingHide.Remove(hwnd);
+            if (!_tracker.IsTracked(hwnd) || NativeMethods.IsWindowVisible(hwnd)) continue;
+
+            if (NativeMethods.IsWindow(hwnd))
+            {
+                Trace.WriteLine($"WindowMonitor: Tracked window {hwnd} remained hidden, restoring in place.");
+                _manager.Restore(hwnd, keepHidden: true);
+                if (_tracker.IsTracked(hwnd))
+                    _pendingHide[hwnd] = Environment.TickCount64 + 5000;
+            }
+            else
+            {
+                _manager.HandleWindowDestroyed(hwnd);
+            }
+        }
+
+        if (_pendingHide.Count == 0)
+            _hideTimer.Stop();
     }
 
     private void MarshalToUiThread(Action action)
     {
-        if (_syncControl.IsDisposed || !_syncControl.IsHandleCreated) return;
+        if (_disposed || _syncControl.IsDisposed || !_syncControl.IsHandleCreated) return;
 
         try
         {
@@ -260,6 +303,10 @@ internal sealed class WindowMonitor : IDisposable
             NativeMethods.UnhookWinEvent(_moveSizeEndHook);
             _moveSizeEndHook = IntPtr.Zero;
         }
+
+        _hideTimer.Stop();
+        _hideTimer.Dispose();
+        _pendingHide.Clear();
 
         Trace.WriteLine("WindowMonitor: Disposed.");
     }


### PR DESCRIPTION
Thank you so much for this tool, I absolutely love it. While using it, I encountered three issues and implemented fixes for each.

## Issues and Changes

- **Minimize button** — When a window was already maximized, dragging the title bar and clicking the minimize button behaved the same as clicking the restore button.
- **Flicker on some applications** — On apps such as Steam and WeChat, maximizing would play the maximize animation on the current desktop followed by the desktop-switch animation, producing a visible flash. The window now completes maximizing on the current desktop before being moved to the new one, without the desktop-switch animation, addressing the flicker issue.
- **Stale desktops on close** — On apps such as Steam and WeChat, closing a maximized window did not restore the original desktop, but rather stays in the current virtual desktop that is empty. The cleanup path now runs correctly.

## A brief demo works like this
<img width="640" height="426" alt="demo" src="https://github.com/user-attachments/assets/d0d51ccf-454a-4fed-92c3-1e6958719716" />


ps: I don't have development experience, and these changes were made with the help of AI. I apologize in advance if anything is incorrect or unconventional. I'd really appreciate any feedback or corrections you're willing to share.
